### PR TITLE
fix: adapt to new Neovim defaults in add_{predicate,directive}

### DIFF
--- a/plugin/hmts.lua
+++ b/plugin/hmts.lua
@@ -159,5 +159,6 @@ local function hmts_inject_handler(match, _, bufnr, predicate, metadata)
 	metadata["injection.language"] = lang
 end
 
-vim.treesitter.query.add_predicate("hmts-path?", hmts_path_handler)
-vim.treesitter.query.add_directive("hmts-inject!", hmts_inject_handler)
+local opts = vim.fn.has("nvim-0.10") == 1 and { force = true, all = false } or true
+vim.treesitter.query.add_predicate("hmts-path?", hmts_path_handler, opts)
+vim.treesitter.query.add_directive("hmts-inject!", hmts_inject_handler, opts)


### PR DESCRIPTION
Fixes #20 and makes hmts-nvim work again for recent unstable Neovim versions.

Adapted from a similar fix for nvim-treesitter:
https://github.com/nvim-treesitter/nvim-treesitter/pull/7114