### PR TITLE
handle nil values

### DIFF
--- a/plugin/hmts.lua
+++ b/plugin/hmts.lua
@@ -124,7 +124,10 @@ end
 ---@param predicate string[]
 ---@return boolean
 local function hmts_path_handler(match, _, bufnr, predicate)
-	local node = match[predicate[2]]:parent()
+    local captured = match[predicate[2]]                                                                                                                                 
+    if type(captured) == "table" then captured = captured[1] end                                                                                                         
+    if not captured then return false end
+    local node = captured:parent()                                                                                                                                       
 	local target_path = vim.list_slice(predicate, 3, nil)
 
 	while node do
@@ -153,6 +156,8 @@ end
 ---@param metadata table<string, string>
 local function hmts_inject_handler(match, _, bufnr, predicate, metadata)
 	local path_node = match[predicate[2]]
+    if type(path_node) == "table" then path_node = path_node[1] end                                                                                                      
+    if not path_node then return end
 	local filename = find_filename_in_parent_node(path_node, bufnr)
 	local alias = vim.filetype.match({ filename = filename })
 


### PR DESCRIPTION
We all love nil - when they're handled ;)

<img width="2677" height="1008" alt="image" src="https://github.com/user-attachments/assets/18dcf1a6-c340-4824-a2a5-4c6f02e785ac" />

Screenshot as text:
```
   Error  02:22:53 msg_show.emsg Decoration provider "start" (ns=nvim.treesitter.highlighter):
Lua: ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:215: ...ugin-hmts.nvim-1.3.0-unstable-2025-06-11/plugin/hmts.lua:127: attempt to call method 'parent' (a nil value)
stack traceback:
	[C]: in function 'f'
	...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:215: in function 'tcall'
	...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:596: in function 'parse'
	....1/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:580: in function <....1/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:557>
```